### PR TITLE
Fallback to response body if text undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = exports = (app) => (args) => {
                     body: JSON.stringify(err)
                 });
 
-            let body = res.text;
+            let body = res.text || res.body;
 
             let contentType = res.headers['content-type'] || 'text/plain';
             contentType = contentType.split(';')[0];


### PR DESCRIPTION
Attempting to serve binary files, e.g. images, from Express apps on IBM Cloud Functions using this package fails, with the error:
```
2019-01-03T12:25:16.16219548Z  stdout: [0mGET /images/logo.svg 200 4.899 ms - 11524
2019-01-03T12:25:16.168950895Z stderr: buffer.js:262
2019-01-03T12:25:16.168963474Z stderr: throw new TypeError(kFromErrorMsg);
2019-01-03T12:25:16.168967702Z stderr: ^
2019-01-03T12:25:16.168971766Z stderr: 
2019-01-03T12:25:16.16897591Z  stderr: TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.
2019-01-03T12:25:16.168980308Z stderr: at fromObject (buffer.js:262:9)
2019-01-03T12:25:16.168984383Z stderr: at Function.Buffer.from (buffer.js:101:10)
2019-01-03T12:25:16.168988546Z stderr: at new Buffer (buffer.js:80:17)
2019-01-03T12:25:16.168992647Z stderr: at Test.req.end (/nodejsAction/iTmyqBdC/node_modules/expressjs-openwhisk/index.js:63:24)
```

The change in this branch fixes that, by falling back to the response object's `body` if `text` is undefined.