### PR TITLE
support font files

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,11 @@ app.patch('/', (req, res) => {
   res.send(req.body);
 });
 
+app.get('/font', (req, res) => {
+  res.set('Content-Type', 'font/woff');
+  res.send(sampleFont);
+});
+
 const forward = require('../index.js')(app);
 
 describe('get', () => {
@@ -99,3 +104,24 @@ describe('put', () => {
     });
   });
 });
+
+describe('get', () => {
+  describe('font', () => {
+    it('should return encoded font', (done) => {
+      forward({
+        __ow_method: 'get',
+        __ow_path: '/font',
+      }).then(res => {
+        assert.equal(wantEncodedFont, res.body);
+        done();
+      });
+    });
+  });
+});
+
+let sampleFont = '';
+for (i = 0; i < 50000; i++) {
+  sampleFont += Math.random().toString(36).substring(2, 15);
+}
+let wantEncodedFont = Buffer.from(sampleFont, 'binary').toString('base64');
+


### PR DESCRIPTION
To support the font files, like ttf/woff/woff2, add two below.

- to reckon the font file as a binary, add a condition that the content-type of response header is 'font/'

- for backward compatibility, add 'application/font-woff2'

- add buffer and a custom parser to buffer the chunk data, which is needed to pass the large font file through